### PR TITLE
(Fabric 1.20.1) Add option to move the spin widget to the right, and force it if Tips is installed

### DIFF
--- a/src/main/java/doggytalents/client/screen/widget/DoggySpin/DoggySpin.java
+++ b/src/main/java/doggytalents/client/screen/widget/DoggySpin/DoggySpin.java
@@ -8,8 +8,10 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
+import net.fabricmc.loader.api.FabricLoader;
 
 public class DoggySpin extends AbstractWidget {
+    private static final String TIPS_MOD_ID = "tipsmod";
 
     private int size;
     private long accumulatedTime = 0;
@@ -66,7 +68,14 @@ public class DoggySpin extends AbstractWidget {
         if (!ConfigHandler.CLIENT.WORD_LOAD_ICON.get())
             return;
         spinWidget.setY(event.getScreen().height - spinWidget.getHeight());
+        if (ConfigHandler.CLIENT.WORLD_LOAD_ICON_RIGHT.get() || isTipsLoaded()) {
+            spinWidget.setX(event.getScreen().width - spinWidget.getWidth() - 10);
+        }
         spinWidget.render(event.getGuiGraphics(), event.getMouseX(), event.getMouseY(), event.getPartialTick());
+    }
+
+    private static boolean isTipsLoaded() {
+        return FabricLoader.getInstance().isModLoaded(TIPS_MOD_ID);
     }
 
     private static boolean isLevelLoadingScreen(ScreenEvent event) {

--- a/src/main/java/doggytalents/common/config/ConfigHandler.java
+++ b/src/main/java/doggytalents/common/config/ConfigHandler.java
@@ -124,6 +124,7 @@ public class ConfigHandler {
         public ForgeConfigSpec.BooleanValue HIDE_WOLF_MOUNT_STATUS;
         public ForgeConfigSpec.BooleanValue SHOW_DOG_NAME_THRU_WALL;
         public ForgeConfigSpec.IntValue MAX_DOG_BED_MODEL_CACHE;
+        public ForgeConfigSpec.BooleanValue WORLD_LOAD_ICON_RIGHT;
 
         //Fabric only
         public ForgeConfigSpec.BooleanValue DOGBED_FORCE_DEFAULT_MODEL;
@@ -306,6 +307,10 @@ public class ConfigHandler {
                 .comment("By default, DTN will render your Dogs' Names through walls. Disable")
                 .comment("this to make Owned Dogs' Names no longer visible through walls.")
                 .define("show_dog_name_thru_wall", true);
+            WORLD_LOAD_ICON_RIGHT = builder
+                .comment("Switch the world load icon to the right. This setting is ignored and forcefully")
+                .comment("treated as true if Tips is installed (so they don't overlap).")
+                .define("world_load_icon_right", false);
             builder.pop();
         }
 


### PR DESCRIPTION
Currently if both mods are installed, the text from Tips and the spinning dog overlap each other. This fixes that by moving it to the right instead, and adding an option in case it's manually required due to some other mod.

I'm not sure how to port this to Forge, but I figure having it on Fabric is at least something for now.